### PR TITLE
[WIP] Add Discord Bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,6 @@ _______
 #### Passport is our authentication management
 
 * Passport is pretty much the best authentication system afaik.
+
+## Discord Bot
+_______

--- a/discord/index.js
+++ b/discord/index.js
@@ -10,6 +10,7 @@ const Team = require('../models/Team');
 const User = require('../models/User');
 const Contract = require('../models/Contract');
 
+//TODO change?
 mongoose.connect('mongodb://' + dbuser +':' + dbpass +
 '@ds147510.mlab.com:47510/olsdev');
 
@@ -21,23 +22,136 @@ bot.on("message", msg => {
 
   if(msg.author.bot) return;
 
+	const args = msg.content.split(" ").splice(1);
+
   if (msg.content.startsWith(prefix + "fuck")) {
     msg.channel.sendMessage("Fuck Smegs!");
   }
+
   else if (msg.content.startsWith(prefix + "fugg")) {
     msg.channel.sendMessage("XD");
   }
 
-	else if (msg.content.startsWith(prefix + "register")) {
+	//TODO better way to create players, if needed on discord at all?
+  //create a new user ex : '-createPlayer <ign> <elo> <isOwner>'
+	else if (msg.content.startsWith(prefix + "createPlayer")) {
+		if (args.length != 3) msg.channel.sendMessage('Usage: -createPlayer <ign> <elo> <isOwner>');
+		else {
+			const a_ign = args[0];
+			const a_elo = parseInt(args[1]);
+			const a_isOwner = (args[2] == 'true');
 
+			//create user
+			let newPlayer = new User({
+				ign: a_ign,
+				elo: a_elo,
+				isOwner: a_isOwner
+			});
+
+			//save the new user
+			newPlayer.save(function(err) {
+				if (err) msg.channel.sendMessage('Error creating new player ' + a_ign);
+				else msg.channel.sendMessage(a_ign + ' successfully created.')
+			});
+		}
 	}
 
+	//add a new team ex : '-createTeam <name> <owner>'
 	else if (msg.content.startsWith(prefix + "createTeam")) {
+		if (args.length != 2) msg.channel.sendMessage('Usage: -createTeam <name> <owner>');
 
+		else {
+			const a_name = args[0];
+			const a_ign = args[1];
+
+			//create team first, save later
+			let newTeam = new Team({
+				name: a_name,
+				owner: a_ign
+			});
+
+			//find the user, make sure they are an owner, and then set their team
+			User.findOne({ign: a_ign}, function(err, user) {
+				if (err || !user) msg.channel.sendMessage('Error finding ' + a_ign);
+				else if (!user.isOwner) msg.channel.sendMessage('Please give ' + a_ign + ' ownership rights first');
+				else {
+					user.team = a_name;
+					user.save(function(err) {
+						if (err) msg.channel.sendMessage('Error updating owner: ' + err);
+						else {
+							//save the team roster
+							newTeam.save(function(err) {
+								if (err) msg.channel.sendMessage('Error creating new team: ' + err);
+								else msg.channel.sendMessage('Team ' + a_name + ' created with owner ' + a_ign);
+							});
+						}
+					})
+				}
+			});
+		}
 	}
 
-	else if (msg.content.startsWith(prefix + "players")) {
+  //list players of a team ex : '-listPlayers <teamName>'
+	else if (msg.content.startsWith(prefix + "listPlayers")) {
+		if (args.length != 1) msg.channel.sendMessage('Usage: -listPlayers <teamName>');
 
+		else {
+			const teamName = args[0];
+
+			//find the team
+			User.find({team: teamName}, function(err, players) {
+				if (err) msg.channel.sendMessage('Error listing players of team ' + teamName + ' : ' + err);
+				if (players.length == 0) msg.channel.sendMessage('Team ' + teamName + ' has no players!');
+				else {
+					//print the roster in one string
+					let outStr = 'Team ' + teamName + ' has:';
+					players.forEach(function(player) {
+						outStr += '\n' + player.ign + ' with an elo of: ' + player.elo;
+					});
+					msg.channel.sendMessage(outStr);
+				}
+			});
+		}
+	}
+
+	//adds a player to a team ex : '-addPlayer <playerName> <teamName>'
+	else if (msg.content.startsWith(prefix + "addPlayer")) {
+		if (args.length != 2) msg.channel.sendMessage('Usage: -addPlayer <playerName> <teamName>');
+
+		else {
+			const playerName = args[0];
+			const teamName = args[1];
+
+			//update the team's roster first
+			Team.findOne({name: teamName}, function(err, team) {
+				if (err) msg.channel.sendMessage('Error updating the ' + teamName + 'roster');
+				else if (!team) msg.channel.sendMessage(teamName + ' does not exist!');
+				else {
+					if (!team.players) team.players = [];
+					team.players.push(playerName);
+
+					//now find the user to update their team
+					User.findOne({ign: playerName}, function(err, user) {
+						if (err) msg.channel.sendMessage('Error updating ' + playerName + '\'s team');
+						if (!user) msg.channel.sendMessage(playerName + ' does not exist!');
+						else {
+							user.team = teamName;
+
+							//don't save team changes unless we know user's succeeds
+							user.save(function(err) {
+								if (err) console.log(err);
+								else {
+									team.save(function(err) {
+										if (err) msg.channel.sendMessage('Error adding ' + playerName + 'to ' + teamName);
+										else msg.channel.sendMessage(playerName + ' added to ' + teamName + ' successfully');
+									});
+								}
+							});
+						}
+					});
+				}
+			});
+		}
 	}
 
 })

--- a/discord/index.js
+++ b/discord/index.js
@@ -1,0 +1,57 @@
+const mongoose = require('mongoose');
+const Discord = require("discord.js");
+const bot = new Discord.Client();
+
+const dbuser = process.argv[3];
+const dbpass = process.argv[4];
+
+//register models
+const Team = require('../models/Team');
+const User = require('../models/User');
+const Contract = require('../models/Contract');
+
+mongoose.connect('mongodb://' + dbuser +':' + dbpass +
+'@ds147510.mlab.com:47510/olsdev');
+
+bot.on("message", msg => {
+
+  let prefix="-"
+
+  if(!msg.content.startsWith(prefix)) return;
+
+  if(msg.author.bot) return;
+
+  if (msg.content.startsWith(prefix + "fuck")) {
+    msg.channel.sendMessage("Fuck Smegs!");
+  }
+  else if (msg.content.startsWith(prefix + "fugg")) {
+    msg.channel.sendMessage("XD");
+  }
+
+	else if (msg.content.startsWith(prefix + "register")) {
+
+	}
+
+	else if (msg.content.startsWith(prefix + "createTeam")) {
+
+	}
+
+	else if (msg.content.startsWith(prefix + "players")) {
+
+	}
+
+})
+
+bot.on("guildMemberAdd", (member) => {
+    console.log(`New User "${member.user.username}" has joined "${member.guild.name}"` );
+    member.guild.defaultChannel.sendMessage(`Welcome to the LoL@Pitt Discord "${member.user.username}"!`);
+});
+
+bot.on('ready', () => {
+  console.log('I am ready');
+})
+
+bot.on('error', e => { console.error(e); });
+
+//TODO find another way to save key
+bot.login(process.argv[2]);

--- a/models/Contract.js
+++ b/models/Contract.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const contractSchema = new Schema({
+	players: [String],
+	startingBid: Number
+});
+
+module.exports = mongoose.model('Contract', contractSchema);

--- a/models/Team.js
+++ b/models/Team.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const teamSchema = new Schema({
+  name: String,
+	owner: String,
+	players: [String]
+});
+
+module.exports = mongoose.model('Team', teamSchema);

--- a/models/User.js
+++ b/models/User.js
@@ -9,5 +9,5 @@ const userSchema = new Schema({
 	elo: Number,
 	team: String
 });
-console.log('user registered');
+
 module.exports = mongoose.model('User', userSchema);

--- a/models/User.js
+++ b/models/User.js
@@ -1,0 +1,13 @@
+let mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const userSchema = new Schema({
+	isOwner: Boolean,
+	isPlayer: Boolean,
+	isAdmin: Boolean,
+	ign: String,
+	elo: Number,
+	team: String
+});
+console.log('user registered');
+module.exports = mongoose.model('User', userSchema);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "babel-cli": "^6.24.0",
     "babel-preset-es2015": "^6.24.0",
     "co": "^4.6.0",
+    "discord.js": "^11.0.0",
     "eslint-plugin-react": "^6.10.3",
     "koa": "^2.2.0",
     "koa-bodyparser": "^4.2.0",


### PR DESCRIPTION
This adds a Discord bot used to run the draft and interact with the site's database via Mongoose/MongoDB.
Also adds /models for use of both the site/bot.

### TODO:
- [ ] Edit/finish all /models for site use
- [ ] Finish adding commands
- [ ] Add a more extensive logger
- [ ] Make sure only admin's can run commands
- [ ] Change how tokens/login info is stored

### Running:
- `git clone`
- `npm install`
- From root directory: `node discord/index.js <discord bot token> <mlab-user username> <mlab-user password>`
- If using a local Mongo instance, change the `mongoose.connect(..)` at the top of index.js


### Current Command List:
- createPlayer
- createTeam
- listPlayers
- addPlayer

### Preview:
 * Command help
![](https://i.gyazo.com/72c9246f84a128054b9025da0c79fdd1.png)

 * Create a new user
![](https://i.gyazo.com/5967415d38a29276f2d29e8984361b64.png)

 * Create a new team
![](https://i.gyazo.com/bedf33b48024f7d41fb7041bb27f6233.png)

 * Add a player to a team
![](https://i.gyazo.com/cb5b62f1795359c209e4e13fac91dff6.png)

 * List players of a team
![](https://i.gyazo.com/5ba29e2e311907edfd0af03b372457fe.png)